### PR TITLE
Manual installation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 MANIFEST
 dist
+build

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 setup(name='pdiffer',
       version='0.0.3',
       description='A Python interface to the PerceptualDiff tool.',
-      long_description=open('README.rst').read().decode('utf-8'),
+      long_description=open('README.rst').read(),
       author='Zachary Voase',
       author_email='z@zacharyvoase.com',
       url='https://github.com/zacharyvoase/pdiffer',


### PR DESCRIPTION
I do not have access to pip at my workplace so I have to manually install python modules.
To recreate the issue that I was having follow these steps:

1. `git clone https://github.com/zacharyvoase/pdiffer.git`
2. `python setup.py install`
3. `Traceback (most recent call last):
  File "setup.py", line 6, in <module>
    long_description=open('README.rst').read().decode('utf-8'),
AttributeError: 'str' object has no attribute 'decode'`

To fix this I removed the `.decode('utf-8')` method since opening the contents of `README.rst` already produces a string. While I was in the codebase I also added the `build` folder to the `.gitignore` since that is created when successfully running `python setup.py install`.

I have not checked if this borks up long_description but it installs and runs.